### PR TITLE
Added: Special Casing for Finding BLSE Dependencies in ModuleManager

### DIFF
--- a/src/Bannerlord.ModuleManager.Models/Issues/ModuleIssueV2.cs
+++ b/src/Bannerlord.ModuleManager.Models/Issues/ModuleIssueV2.cs
@@ -101,7 +101,7 @@ internal
 #else
 public
 # endif
-    sealed record ModuleMissingUnversionedDependencyIssue(
+    record ModuleMissingUnversionedDependencyIssue(
     ModuleInfoExtended Module,
     DependentModuleMetadata Dependency
 ) : ModuleIssueV2(Module)
@@ -111,6 +111,50 @@ public
         Module,
         Dependency.Id,
         ModuleIssueType.MissingDependencies,
+        ToString(),
+        ApplicationVersionRange.Empty);
+}
+
+/// <summary>
+///     Represents an issue where the `Bannerlord Software Extender` (BLSE) is missing.
+/// </summary>
+/// <param name="Module">The module with the missing dependency</param>
+/// <param name="Dependency">The missing dependency module</param>
+/// <remarks>
+/// This issue occurs when a mod requires the `Bannerlord Software Extender` (BLSE)
+/// but it is not installed.
+/// 
+/// Example scenario:
+/// ```xml
+/// <Module>
+///     <!-- 👇 Current mod is `SimpleTournaments` -->
+///     <Id value="SimpleTournaments"/>
+///     <DependedModules>
+///         <!-- 👇 This dependency `BLSE.AssemblyResolver` is provided by BLSE -->
+///         <DependedModule Id="BLSE.AssemblyResolver" />
+/// 
+///         <!-- 👇 This dependency `BLSE.LoadingInterceptor` is provided by BLSE -->
+///         <DependedModule Id="BLSE.LoadingInterceptor" />
+///     </DependedModules>
+/// </Module>
+/// ```
+/// If `BLSE` is not installed at all, this issue will be raised if `SimpleTournaments` is enabled.
+/// </remarks>
+#if !BANNERLORDBUTRMODULEMANAGER_PUBLIC
+internal
+#else
+public
+# endif
+    sealed record ModuleMissingBLSEDependencyIssue(
+        ModuleInfoExtended Module,
+        DependentModuleMetadata Dependency
+    ) : ModuleMissingUnversionedDependencyIssue(Module, Dependency)
+{
+    public override string ToString() => $"Missing Bannerlord Software Extender";
+    public override LegacyModuleIssue ToLegacy() => new(
+        Module,
+        Dependency.Id,
+        ModuleIssueType.MissingBLSE,
         ToString(),
         ApplicationVersionRange.Empty);
 }

--- a/src/Bannerlord.ModuleManager.Models/Issues/ModuleIssueV2.cs
+++ b/src/Bannerlord.ModuleManager.Models/Issues/ModuleIssueV2.cs
@@ -101,7 +101,7 @@ internal
 #else
 public
 # endif
-    record ModuleMissingUnversionedDependencyIssue(
+    sealed record ModuleMissingUnversionedDependencyIssue(
     ModuleInfoExtended Module,
     DependentModuleMetadata Dependency
 ) : ModuleIssueV2(Module)
@@ -148,7 +148,7 @@ public
     sealed record ModuleMissingBLSEDependencyIssue(
         ModuleInfoExtended Module,
         DependentModuleMetadata Dependency
-    ) : ModuleMissingUnversionedDependencyIssue(Module, Dependency)
+    ) : ModuleIssueV2(Module)
 {
     public override string ToString() => $"Missing Bannerlord Software Extender";
     public override LegacyModuleIssue ToLegacy() => new(

--- a/src/Bannerlord.ModuleManager.Models/ModuleIssueType.cs
+++ b/src/Bannerlord.ModuleManager.Models/ModuleIssueType.cs
@@ -56,6 +56,8 @@ public
     MissingModuleName,
     DependencyIsNull,
     DependencyMissingModuleId,
+    
+    MissingBLSE,
 }
 
 #nullable restore

--- a/src/Bannerlord.ModuleManager/ModuleUtilities.cs
+++ b/src/Bannerlord.ModuleManager/ModuleUtilities.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // MIT License
 //
 // Copyright (c) Bannerlord's Unofficial Tools & Resources
@@ -427,6 +427,13 @@ public
 
             if (!modules.Any(x => string.Equals(x.Id, metadata.Id, StringComparison.Ordinal)))
             {
+                // For BLSE, there is a special case, 
+                if (metadata.Id is "BLSE.LoadingInterceptor" or "BLSE.AssemblyResolver")
+                {
+                    yield return new ModuleMissingBLSEDependencyIssue(targetModule, metadata);
+                    yield break;
+                }
+
                 if (metadata.Version != ApplicationVersion.Empty)
                     yield return new ModuleMissingExactVersionDependencyIssue(targetModule, metadata);
                 else if (metadata.VersionRange != ApplicationVersionRange.Empty)
@@ -600,6 +607,13 @@ public
                 
             if (metadataIdx == -1)
             {
+                // For BLSE, there is a special case, 
+                if (metadata.Id is "BLSE.LoadingInterceptor" or "BLSE.AssemblyResolver")
+                {
+                    yield return new ModuleMissingBLSEDependencyIssue(targetModule, metadata);
+                    yield break;
+                }
+                
                 // If the dependency lacks an Id, it's not valid
                 if (!string.IsNullOrWhiteSpace(metadata.Id) && !metadata.IsOptional)
                 {

--- a/src/Bannerlord.ModuleManager/ModuleUtilities.cs
+++ b/src/Bannerlord.ModuleManager/ModuleUtilities.cs
@@ -429,12 +429,8 @@ public
             {
                 // For BLSE, there is a special case, 
                 if (metadata.Id is "BLSE.LoadingInterceptor" or "BLSE.AssemblyResolver")
-                {
                     yield return new ModuleMissingBLSEDependencyIssue(targetModule, metadata);
-                    yield break;
-                }
-
-                if (metadata.Version != ApplicationVersion.Empty)
+                else if (metadata.Version != ApplicationVersion.Empty)
                     yield return new ModuleMissingExactVersionDependencyIssue(targetModule, metadata);
                 else if (metadata.VersionRange != ApplicationVersionRange.Empty)
                     yield return new ModuleMissingVersionRangeDependencyIssue(targetModule, metadata);
@@ -609,13 +605,10 @@ public
             {
                 // For BLSE, there is a special case, 
                 if (metadata.Id is "BLSE.LoadingInterceptor" or "BLSE.AssemblyResolver")
-                {
                     yield return new ModuleMissingBLSEDependencyIssue(targetModule, metadata);
-                    yield break;
-                }
                 
                 // If the dependency lacks an Id, it's not valid
-                if (!string.IsNullOrWhiteSpace(metadata.Id) && !metadata.IsOptional)
+                else if (!string.IsNullOrWhiteSpace(metadata.Id) && !metadata.IsOptional)
                 {
                     if (metadata.Version != ApplicationVersion.Empty)
                         yield return new ModuleMissingExactVersionDependencyIssue(targetModule, metadata);

--- a/src/Bannerlord.ModuleManager/ModuleUtilities.cs
+++ b/src/Bannerlord.ModuleManager/ModuleUtilities.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // MIT License
 //
 // Copyright (c) Bannerlord's Unofficial Tools & Resources
@@ -273,7 +273,7 @@ public
         bool validateDependencies = true)
     {
         var visited = new HashSet<ModuleInfoExtended>();
-        foreach (var issue in ValidateModuleEx(modules, targetModule, visited, isSelected, isValid))
+        foreach (var issue in ValidateModuleEx(modules, targetModule, visited, isSelected, isValid, validateDependencies))
         {
             yield return issue;
         }


### PR DESCRIPTION
This emits a new error `ModuleMissingBLSEDependencyIssue`, for when dependencies of BLSE specifically are missing.
This gets a new issue type in both the new, and old API.

From there, launchers can display a message if BLSE is missing when it is required by a mod.